### PR TITLE
Handle error of unexpected api response structure

### DIFF
--- a/src/normaliseResponse.ts
+++ b/src/normaliseResponse.ts
@@ -13,7 +13,10 @@ function parseData(data: string) {
 
 export function normaliseResponse(rawBody: string, raw = false): TranslationResult {
   const data = parseData(rawBody);
-  const translatedPhrases = data[1][0][0][5];
+  const translatedPhrases = data[1]?.[0]?.[0]?.[5];
+  if (!Array.isArray(translatedPhrases)) {
+    throw new Error("Unexpected response structure");
+  }
   const text = translatedPhrases.reduce<string>((fullText, [textBlock]) => {
     return fullText ? `${fullText} ${textBlock}` : textBlock;
   }, "");


### PR DESCRIPTION
When a url is provided as text, the api returns a weird data instead of an error. This causes data[1][0][0][5] to be undefined.
This PR doesn't fix the error, but provides an information about the problem.

You might want to consider returning the text itself if the text matches with a URL regex pattern. But since that would be a decision, I didn't want to include that to this PR.